### PR TITLE
Hide panel area buttons when user role does not have access

### DIFF
--- a/snippets/admin-bar.php
+++ b/snippets/admin-bar.php
@@ -157,6 +157,9 @@ $user = kirby()->user()
 
 <div class="admin-bar">
     <?php
+    /**
+     * @var Kirby\Cms\Page $page
+     */
     $panelLanguage = $user->language();
     $siteLanguage = kirby()->language();
     kirby()->setCurrentTranslation($panelLanguage);
@@ -164,9 +167,10 @@ $user = kirby()->user()
     $userName = $user->name()->or($user->username());
     $avatar = $user->avatar();
     $pageEditLink = $page->panelUrl()->or($page->panel()->url());
-    $status = $page->status();
-    $panelAreas = Panel::areas();
-    $visiblePanelAreas = array_filter($panelAreas, fn($panelArea) => $panelArea['menu']);
+    $permissions = $user->role()->permissions();
+    $visiblePanelAreas = array_filter(Panel::areas(), function($panelArea) use ($permissions) {
+        return $panelArea['menu'] && $permissions->for('access', $panelArea['id'], true);
+    });
     ?>
     <div class="admin-bar__links">
         <?php if (!$page->disableEditButton()->toBool()): ?>


### PR DESCRIPTION
The current implementation loops over `Kirby\Panel\Panel::areas()` and lists all areas which have a truthy `'menu'` value.

When the current user has a role with some restricted access permissions, for instance:

```yaml
title: Editor
permissions:
  access:
    account: true
    panel: true
    site: true
    languages: false
    system: false
    users: false
```

(Relevant docs: https://getkirby.com/docs/guide/users/permissions#role-based-permissions-in-user-blueprints)

then the Admin Bar will still list areas like “System” or “Users” that the user doesn't have access to. Following these links will show an error page.

This PR adds a check for `$user->role()->permissions()->for('access', $panelArea['id'])` to make sure that the user role allows access to a given area.

Note than an area added by a plugin may not have a boolean value defined in `$user->role()->permissions()`. In that case, users would have access to that area, but `$user->role()->permissions()->for('access', $panelArea['id'])` may return false. We can work around this by using `true` as the default value in the `for()` method.

Example with an admin account and then an editor account:

![Screen Shot 2025-04-09 at 18 03 47](https://github.com/user-attachments/assets/4b6be76a-0432-462f-ba73-8f66757951b9)

![Screen Shot 2025-04-09 at 18 04 18](https://github.com/user-attachments/assets/804d91e8-d311-457c-b3a4-e6266c93f40f)
